### PR TITLE
Fix gate overwrite issue

### DIFF
--- a/src/Controllers/ScalarController.php
+++ b/src/Controllers/ScalarController.php
@@ -9,8 +9,8 @@ class ScalarController extends Controller
 {
     public function __invoke()
     {
-        if (! Gate::check('viewScalar') && ! app()->environment('local')) {
-            return abort(403);
+        if (! app()->environment('local')) {
+            abort_unless(Gate::check('viewScalar'), 403);
         }
 
         return view('scalar::reference');


### PR DESCRIPTION
Updated the `viewScalar` access check to explicitly bypass the Gate in the `local` environment while preserving Gate validation in all other environments.

Changes
1. Skip `Gate::check('viewScalar')` entirely when running in the `local` environment.
2. Enforce `Gate::check('viewScalar')` in non-local environments.
3. Prevent local environment bypass logic from interfering with Gate overrides in staging and production.

This ensures Gate overrides continue to work correctly in environments other than `local`.