### PR TITLE
chore: update deps and test PHP 8.4 + 8.5

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -17,12 +17,21 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest]
-        php: [8.3, 8.2]
+        php: [8.5, 8.4, 8.3, 8.2]
         laravel: [13.*, 12.*, 11.*, 10.*]
         stability: [prefer-lowest, prefer-stable]
         exclude:
+          # Laravel 13 dropped PHP 8.2
           - php: 8.2
             laravel: 13.*
+          # Laravel 10 only supports up to PHP 8.3
+          - php: 8.4
+            laravel: 10.*
+          - php: 8.5
+            laravel: 10.*
+          # Laravel 11 only supports up to PHP 8.4
+          - php: 8.5
+            laravel: 11.*
         include:
           - laravel: 13.*
             testbench: 11.*

--- a/composer.json
+++ b/composer.json
@@ -25,9 +25,9 @@
         "laravel/pint": "^1.14",
         "nunomaduro/collision": "^8.7.0||^7.10.0",
         "orchestra/testbench": "^8.0||^9.0||^10.0||^11.0",
-        "pestphp/pest": "^2.3.4||^3.7.4||^4.0",
-        "pestphp/pest-plugin-arch": "^2.7.0||^3.0.0||^4.0",
-        "pestphp/pest-plugin-laravel": "^2.3.0||^3.1.0||^4.0"
+        "pestphp/pest": "^2.3.4||^3.7.4||^4.0||^5.0",
+        "pestphp/pest-plugin-arch": "^2.7.0||^3.0.0||^4.0||^5.0",
+        "pestphp/pest-plugin-laravel": "^2.3.0||^3.1.0||^4.0||^5.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Bumps dev dependencies (Pest 5, Testbench 11, and minor bumps) and adds PHP 8.4 and 8.5 to the test matrix. Older Laravel versions that don't support those PHP versions are excluded. Tests pass locally on PHP 8.4.