### PR TITLE
feat: support local OpenAPI documents (content + file)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,29 +41,30 @@ You’ll need an OpenAPI (formerly Swagger) document to render your API referenc
 * [knuckleswtf/scribe](https://github.com/knuckleswtf/scribe)
 * [vyuldashev/laravel-openapi](https://github.com/vyuldashev/laravel-openapi)
 
-Point Scalar at your document through the `url` option — a path served by your own app or an absolute URL:
+Point Scalar at your document in `config/scalar.php`. You can provide it in three ways:
+
+**A URL** fetched by the browser — a path served by your own app, or an absolute URL:
 
 ```php
-<?php
-
-// config/scalar.php
-
-return [
-    // …
-
-    // A file in your public directory, a route that returns the document, …
-    'url' => '/openapi.yaml',
-
-    // … or an absolute URL:
-    // 'url' => 'https://example.com/openapi.json',
-
-    // …
-];
+'url' => '/openapi.yaml',
+// 'url' => 'https://example.com/openapi.json',
 ```
 
-The document is fetched in the browser, so a relative URL just needs to be reachable on the same origin. An absolute, cross-origin URL needs to be publicly accessible (and may go through the built-in `proxyUrl`).
+A relative URL just needs to be reachable on the same origin. An absolute, cross-origin URL needs to be publicly accessible (and may go through the built-in `proxyUrl`).
 
-Then visit `/scalar` to see your API reference.
+**A local file** read on the server and embedded in the page — it never needs to be publicly accessible:
+
+```php
+'file' => storage_path('app/openapi.json'),
+```
+
+**Inline content** — the raw OpenAPI document as a JSON or YAML string:
+
+```php
+'content' => '{ "openapi": "3.1.0", "info": { "title": "My API", "version": "1.0.0" } }',
+```
+
+When more than one is set, `file` takes precedence over `content`, which takes precedence over `url`. Then visit `/scalar` to see your API reference.
 
 ## Theme
 

--- a/config/scalar.php
+++ b/config/scalar.php
@@ -52,6 +52,32 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Scalar OpenAPI Document Content
+    |--------------------------------------------------------------------------
+    |
+    | Instead of fetching the document from a URL, you can embed it directly in
+    | the page. Provide the raw OpenAPI document as a JSON or YAML string. When
+    | set, this takes precedence over the URL above and the browser makes no
+    | extra request for the document.
+    |
+    */
+    'content' => null,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Scalar OpenAPI Document File
+    |--------------------------------------------------------------------------
+    |
+    | Path to a local OpenAPI document (for example storage_path('app/openapi.
+    | json')). The file is read on the server and embedded in the page, so it
+    | never needs to be publicly accessible. This takes precedence over both
+    | the content and URL options above.
+    |
+    */
+    'file' => null,
+
+    /*
+    |--------------------------------------------------------------------------
     | Scalar CDN URL
     |--------------------------------------------------------------------------
     |

--- a/src/Exceptions/MissingOpenApiDocument.php
+++ b/src/Exceptions/MissingOpenApiDocument.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Scalar\Exceptions;
+
+use RuntimeException;
+
+class MissingOpenApiDocument extends RuntimeException {}

--- a/src/Facades/Scalar.php
+++ b/src/Facades/Scalar.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Facades\Facade;
 /**
  * @method static string pageTitle()
  * @method static string|null url()
+ * @method static string|null content()
  * @method static string cdn()
  * @method static \Illuminate\Support\Collection<array-key, mixed> configuration()
  *

--- a/src/Scalar.php
+++ b/src/Scalar.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Scalar;
 
 use Illuminate\Support\Collection;
+use Scalar\Exceptions\MissingOpenApiDocument;
 
 class Scalar
 {
@@ -25,7 +26,28 @@ class Scalar
     {
         $url = config('scalar.url');
 
-        return is_string($url) ? $url : null;
+        return is_string($url) && $url !== '' ? $url : null;
+    }
+
+    public static function content(): ?string
+    {
+        /** A local file is read on the server and embedded in the page. */
+        $file = config('scalar.file');
+
+        if (is_string($file) && $file !== '') {
+            if (! is_file($file)) {
+                throw new MissingOpenApiDocument(
+                    "The configured OpenAPI document could not be found at: {$file}"
+                );
+            }
+
+            return (string) file_get_contents($file);
+        }
+
+        /** Otherwise, use the inline content as-is. */
+        $content = config('scalar.content');
+
+        return is_string($content) && $content !== '' ? $content : null;
     }
 
     public static function cdn(): string
@@ -51,10 +73,21 @@ class Scalar
         /** Add Laravel integration identifier */
         $configuration['_integration'] ??= 'laravel';
 
+        /** Resolve the OpenAPI document: inline content takes precedence over a URL. */
+        $content = self::content();
+        $url = self::url();
+
+        if ($content === null && $url === null) {
+            throw new MissingOpenApiDocument(
+                'No OpenAPI document configured. Set the `url`, `content`, or `file` option in config/scalar.php.'
+            );
+        }
+
         /** Render as JSON */
         return collect($configuration)->merge([
             'theme' => $theme,
-            'url' => config('scalar.url'),
-        ]);
+        ])->merge(
+            $content !== null ? ['content' => $content] : ['url' => $url]
+        );
     }
 }

--- a/src/Scalar.php
+++ b/src/Scalar.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Scalar;
 
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\File;
 use Scalar\Exceptions\MissingOpenApiDocument;
 
 class Scalar
@@ -41,7 +42,7 @@ class Scalar
                 );
             }
 
-            return (string) file_get_contents($file);
+            return File::get($file);
         }
 
         /** Otherwise, use the inline content as-is. */

--- a/tests/Fixtures/openapi.json
+++ b/tests/Fixtures/openapi.json
@@ -1,0 +1,8 @@
+{
+    "openapi": "3.1.0",
+    "info": {
+        "title": "Fixture API",
+        "version": "1.0.0"
+    },
+    "paths": {}
+}

--- a/tests/ScalarTest.php
+++ b/tests/ScalarTest.php
@@ -4,6 +4,7 @@ use Illuminate\Auth\GenericUser;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Route;
 use Scalar\Controllers\ScalarController;
+use Scalar\Exceptions\MissingOpenApiDocument;
 use Scalar\Scalar;
 
 it('registers the route', function () {
@@ -154,4 +155,45 @@ it('publishes the config file via the install command', function () {
         ->expectsConfirmation('Would you like to star our repo on GitHub?', 'no')
         ->expectsOutputToContain('Point Scalar at your OpenAPI document')
         ->assertExitCode(0);
+});
+
+it('embeds raw content and drops the url when content is set', function () {
+    config()->set('scalar.content', '{"openapi":"3.1.0"}');
+
+    $configuration = Scalar::configuration();
+
+    expect($configuration['content'])->toBe('{"openapi":"3.1.0"}')
+        ->and($configuration->has('url'))->toBeFalse();
+});
+
+it('embeds a local file as content, taking precedence over content and url', function () {
+    config()->set('scalar.file', __DIR__.'/Fixtures/openapi.json');
+    config()->set('scalar.content', '{"openapi":"3.1.0"}');
+
+    $configuration = Scalar::configuration();
+
+    expect($configuration['content'])->toContain('Fixture API')
+        ->and($configuration->has('url'))->toBeFalse();
+});
+
+it('throws when the configured file does not exist', function () {
+    config()->set('scalar.file', __DIR__.'/Fixtures/does-not-exist.json');
+
+    Scalar::configuration();
+})->throws(MissingOpenApiDocument::class);
+
+it('throws when no OpenAPI document is configured', function () {
+    config()->set('scalar.url', null);
+    config()->set('scalar.content', null);
+    config()->set('scalar.file', null);
+
+    Scalar::configuration();
+})->throws(MissingOpenApiDocument::class);
+
+it('renders inline content through the reference view', function () {
+    config()->set('scalar.content', '{"openapi":"3.1.0","info":{"title":"Inline"}}');
+
+    $this->get(config('scalar.path'))
+        ->assertOk()
+        ->assertSee('"content":', false);
 });

--- a/tests/ScalarTest.php
+++ b/tests/ScalarTest.php
@@ -190,6 +190,29 @@ it('throws when no OpenAPI document is configured', function () {
     Scalar::configuration();
 })->throws(MissingOpenApiDocument::class);
 
+it('treats an empty url as no document', function () {
+    config()->set('scalar.url', '');
+    config()->set('scalar.content', null);
+    config()->set('scalar.file', null);
+
+    Scalar::configuration();
+})->throws(MissingOpenApiDocument::class);
+
+it('treats empty content as no document', function () {
+    config()->set('scalar.url', null);
+    config()->set('scalar.content', '');
+    config()->set('scalar.file', null);
+
+    Scalar::configuration();
+})->throws(MissingOpenApiDocument::class);
+
+it('ignores an empty file path and falls back to content', function () {
+    config()->set('scalar.file', '');
+    config()->set('scalar.content', '{"openapi":"3.1.0"}');
+
+    expect(Scalar::configuration()['content'])->toBe('{"openapi":"3.1.0"}');
+});
+
 it('renders inline content through the reference view', function () {
     config()->set('scalar.content', '{"openapi":"3.1.0","info":{"title":"Inline"}}');
 


### PR DESCRIPTION
Removes the biggest adoption friction: you no longer need a publicly hosted OpenAPI document.

Adds two new ways to provide your document in `config/scalar.php`, alongside the existing `url`:

- **`file`** — a path to a local OpenAPI document (e.g. `storage_path('app/openapi.json')`). Read on the server and embedded in the page, so it never needs to be publicly accessible.
- **`content`** — the raw OpenAPI document as a JSON/YAML string, embedded inline (no extra browser request).

Precedence is `file` > `content` > `url`. When none is configured (or a `file` path is missing), Scalar now throws a clear `MissingOpenApiDocument` exception instead of silently rendering an empty reference.

No breaking changes — the default config still uses `url`.