### PR TITLE
feat: manager for multiple & versioned documents

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,32 @@ When more than one is set, `file` takes precedence over `content`, which takes p
 
 The reference ships with a Laravel-flavored theme, enabled by default (`'theme' => 'laravel'` in the config). Scalar also comes with a range of built-in themes — see the `configuration.theme` option in `config/scalar.php` for the full list.
 
+## Multiple documents
+
+Render more than one OpenAPI document behind a document switcher — useful for versioned APIs (`v1`, `v2`) or public vs. internal references. Define them in the `sources` config:
+
+```php
+// config/scalar.php
+
+'sources' => [
+    ['title' => 'API v1', 'slug' => 'v1', 'url' => '/openapi/v1.yaml'],
+    ['title' => 'API v2', 'slug' => 'v2', 'url' => '/openapi/v2.yaml', 'default' => true],
+],
+```
+
+Each source accepts a `title`, an optional `slug`, one of `url`/`content`/`file`, and an optional `default` flag.
+
+You can also register documents at runtime with the `Scalar` facade — for example in a service provider — which is handy when the list is dynamic:
+
+```php
+use Scalar\Facades\Scalar;
+
+Scalar::document('API v1')->url('/openapi/v1.yaml');
+Scalar::document('API v2')->file(storage_path('app/openapi/v2.json'))->default();
+```
+
+Registered documents take precedence over the `sources` config.
+
 ## Authorization
 
 The Scalar API reference may be accessed via the /scalar route. By default, everyone will be able to access this route. However, within your App\Providers\AppServiceProvider.php file, you can overwrite the gate definition. This authorization gate controls access to Scalar in non-local environments. You are free to modify this gate as needed to restrict access to your documentation:

--- a/config/scalar.php
+++ b/config/scalar.php
@@ -78,6 +78,35 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Scalar OpenAPI Documents (multiple / versioned)
+    |--------------------------------------------------------------------------
+    |
+    | Render more than one OpenAPI document behind a document switcher. Each
+    | source accepts a `title`, an optional `slug`, one of `url`/`content`/
+    | `file`, and an optional `default` flag. When set, this takes precedence
+    | over the single-document options above.
+    |
+    | You can also register documents at runtime with the Scalar facade:
+    |
+    |     Scalar::document('API v2')->url('/openapi/v2.yaml')->default();
+    |
+    */
+    'sources' => [
+        // [
+        //     'title' => 'API v1',
+        //     'slug' => 'v1',
+        //     'url' => '/openapi/v1.yaml',
+        // ],
+        // [
+        //     'title' => 'API v2',
+        //     'slug' => 'v2',
+        //     'url' => '/openapi/v2.yaml',
+        //     'default' => true,
+        // ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Scalar CDN URL
     |--------------------------------------------------------------------------
     |

--- a/resources/views/layout.blade.php
+++ b/resources/views/layout.blade.php
@@ -2,7 +2,7 @@
 <html>
 
 <head>
-    <title>{{ \Scalar\Scalar::pageTitle() }}</title>
+    <title>{{ \Scalar\Facades\Scalar::pageTitle() }}</title>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     @if (config('scalar.configuration.theme') === 'laravel')

--- a/resources/views/reference.blade.php
+++ b/resources/views/reference.blade.php
@@ -3,9 +3,9 @@
 @section('content')
     <div id="app"></div>
 
-    <script src="{{ \Scalar\Scalar::cdn() }}"></script>
+    <script src="{{ \Scalar\Facades\Scalar::cdn() }}"></script>
 
     <script>
-       Scalar.createApiReference('#app', {!! \Scalar\Scalar::configuration() !!})
+       Scalar.createApiReference('#app', {!! \Scalar\Facades\Scalar::configuration() !!})
     </script>
 @endsection

--- a/src/Document.php
+++ b/src/Document.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Scalar;
+
+use Illuminate\Support\Facades\File;
+use Scalar\Exceptions\MissingOpenApiDocument;
+
+final class Document
+{
+    protected ?string $title = null;
+
+    protected ?string $slug = null;
+
+    protected ?string $url = null;
+
+    protected ?string $content = null;
+
+    protected ?string $file = null;
+
+    protected bool $default = false;
+
+    public function title(string $title): static
+    {
+        $this->title = $title;
+
+        return $this;
+    }
+
+    public function slug(string $slug): static
+    {
+        $this->slug = $slug;
+
+        return $this;
+    }
+
+    public function url(string $url): static
+    {
+        $this->url = $url;
+
+        return $this;
+    }
+
+    public function content(string $content): static
+    {
+        $this->content = $content;
+
+        return $this;
+    }
+
+    public function file(string $file): static
+    {
+        $this->file = $file;
+
+        return $this;
+    }
+
+    public function default(bool $default = true): static
+    {
+        $this->default = $default;
+
+        return $this;
+    }
+
+    /**
+     * @param  array<array-key, mixed>  $source
+     */
+    public static function fromArray(array $source): self
+    {
+        $document = new self;
+
+        $title = $source['title'] ?? null;
+        if (is_string($title)) {
+            $document->title($title);
+        }
+
+        $slug = $source['slug'] ?? null;
+        if (is_string($slug)) {
+            $document->slug($slug);
+        }
+
+        $url = $source['url'] ?? null;
+        if (is_string($url)) {
+            $document->url($url);
+        }
+
+        $content = $source['content'] ?? null;
+        if (is_string($content)) {
+            $document->content($content);
+        }
+
+        $file = $source['file'] ?? null;
+        if (is_string($file)) {
+            $document->file($file);
+        }
+
+        if (($source['default'] ?? false) === true) {
+            $document->default();
+        }
+
+        return $document;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $source = [];
+
+        if ($this->title !== null) {
+            $source['title'] = $this->title;
+        }
+
+        if ($this->slug !== null) {
+            $source['slug'] = $this->slug;
+        }
+
+        $content = $this->resolveContent();
+
+        if ($content !== null) {
+            $source['content'] = $content;
+        } elseif ($this->url !== null && $this->url !== '') {
+            $source['url'] = $this->url;
+        } else {
+            throw new MissingOpenApiDocument(
+                'A Scalar document needs a `url`, `content`, or `file`.'
+            );
+        }
+
+        if ($this->default) {
+            $source['default'] = true;
+        }
+
+        return $source;
+    }
+
+    protected function resolveContent(): ?string
+    {
+        if ($this->file !== null && $this->file !== '') {
+            if (! is_file($this->file)) {
+                throw new MissingOpenApiDocument(
+                    "The configured OpenAPI document could not be found at: {$this->file}"
+                );
+            }
+
+            return File::get($this->file);
+        }
+
+        return $this->content !== null && $this->content !== '' ? $this->content : null;
+    }
+}

--- a/src/Facades/Scalar.php
+++ b/src/Facades/Scalar.php
@@ -7,6 +7,8 @@ namespace Scalar\Facades;
 use Illuminate\Support\Facades\Facade;
 
 /**
+ * @method static \Scalar\Document document(?string $title = null)
+ * @method static array<array-key, \Scalar\Document> documents()
  * @method static string pageTitle()
  * @method static string|null url()
  * @method static string|null content()

--- a/src/Scalar.php
+++ b/src/Scalar.php
@@ -10,7 +10,51 @@ use Scalar\Exceptions\MissingOpenApiDocument;
 
 class Scalar
 {
-    public static function pageTitle(): string
+    /**
+     * Documents registered programmatically.
+     *
+     * @var array<int, Document>
+     */
+    protected array $documents = [];
+
+    public function document(?string $title = null): Document
+    {
+        $document = new Document;
+
+        if ($title !== null) {
+            $document->title($title);
+        }
+
+        $this->documents[] = $document;
+
+        return $document;
+    }
+
+    /**
+     * Resolve the documents to render: registered documents first, then the
+     * `sources` config, otherwise fall back to a single-document setup.
+     *
+     * @return array<array-key, Document>
+     */
+    public function documents(): array
+    {
+        if ($this->documents !== []) {
+            return $this->documents;
+        }
+
+        $sources = config('scalar.sources');
+
+        if (is_array($sources) && $sources !== []) {
+            return array_map(
+                fn (mixed $source): Document => Document::fromArray(is_array($source) ? $source : []),
+                $sources
+            );
+        }
+
+        return [];
+    }
+
+    public function pageTitle(): string
     {
         $title = config('scalar.configuration.metaData.title');
 
@@ -23,14 +67,14 @@ class Scalar
         return (is_string($name) ? $name : 'Laravel').' API Reference';
     }
 
-    public static function url(): ?string
+    public function url(): ?string
     {
         $url = config('scalar.url');
 
         return is_string($url) && $url !== '' ? $url : null;
     }
 
-    public static function content(): ?string
+    public function content(): ?string
     {
         /** A local file is read on the server and embedded in the page. */
         $file = config('scalar.file');
@@ -51,7 +95,7 @@ class Scalar
         return is_string($content) && $content !== '' ? $content : null;
     }
 
-    public static function cdn(): string
+    public function cdn(): string
     {
         $cdn = config('scalar.cdn');
 
@@ -61,7 +105,7 @@ class Scalar
     /**
      * @return Collection<array-key, mixed>
      */
-    public static function configuration(): Collection
+    public function configuration(): Collection
     {
         $configuration = config('scalar.configuration');
         $configuration = is_array($configuration) ? $configuration : [];
@@ -74,20 +118,28 @@ class Scalar
         /** Add Laravel integration identifier */
         $configuration['_integration'] ??= 'laravel';
 
-        /** Resolve the OpenAPI document: inline content takes precedence over a URL. */
-        $content = self::content();
-        $url = self::url();
+        $base = collect($configuration)->merge(['theme' => $theme]);
+
+        /** Multiple/versioned documents render through a `sources` array. */
+        $documents = $this->documents();
+
+        if ($documents !== []) {
+            return $base->merge([
+                'sources' => array_map(fn (Document $document): array => $document->toArray(), $documents),
+            ]);
+        }
+
+        /** Otherwise, fall back to a single document: content takes precedence over a URL. */
+        $content = $this->content();
+        $url = $this->url();
 
         if ($content === null && $url === null) {
             throw new MissingOpenApiDocument(
-                'No OpenAPI document configured. Set the `url`, `content`, or `file` option in config/scalar.php.'
+                'No OpenAPI document configured. Set the `url`, `content`, `file`, or `sources` option in config/scalar.php.'
             );
         }
 
-        /** Render as JSON */
-        return collect($configuration)->merge([
-            'theme' => $theme,
-        ])->merge(
+        return $base->merge(
             $content !== null ? ['content' => $content] : ['url' => $url]
         );
     }

--- a/src/ScalarServiceProvider.php
+++ b/src/ScalarServiceProvider.php
@@ -12,6 +12,11 @@ use Spatie\LaravelPackageTools\PackageServiceProvider;
 
 class ScalarServiceProvider extends PackageServiceProvider
 {
+    public function packageRegistered(): void
+    {
+        $this->app->singleton(Scalar::class);
+    }
+
     public function boot(): void
     {
         parent::boot();

--- a/tests/ScalarTest.php
+++ b/tests/ScalarTest.php
@@ -4,8 +4,9 @@ use Illuminate\Auth\GenericUser;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Route;
 use Scalar\Controllers\ScalarController;
+use Scalar\Document;
 use Scalar\Exceptions\MissingOpenApiDocument;
-use Scalar\Scalar;
+use Scalar\Facades\Scalar;
 
 it('registers the route', function () {
     $routes = Route::getRoutes();
@@ -219,4 +220,157 @@ it('renders inline content through the reference view', function () {
     $this->get(config('scalar.path'))
         ->assertOk()
         ->assertSee('"content":', false);
+});
+
+/*
+|--------------------------------------------------------------------------
+| Multiple / versioned documents
+|--------------------------------------------------------------------------
+*/
+
+it('renders a registered document as a source', function () {
+    Scalar::document('API v1')->url('/openapi/v1.yaml');
+
+    expect(Scalar::configuration()['sources'])->toBe([
+        ['title' => 'API v1', 'url' => '/openapi/v1.yaml'],
+    ]);
+});
+
+it('renders multiple registered documents as sources', function () {
+    Scalar::document('API v1')->url('/openapi/v1.yaml');
+    Scalar::document('API v2')->slug('v2')->url('/openapi/v2.yaml')->default();
+
+    expect(Scalar::configuration()['sources'])->toBe([
+        ['title' => 'API v1', 'url' => '/openapi/v1.yaml'],
+        ['title' => 'API v2', 'slug' => 'v2', 'url' => '/openapi/v2.yaml', 'default' => true],
+    ]);
+});
+
+it('renders documents from the sources config', function () {
+    config()->set('scalar.sources', [
+        ['title' => 'v1', 'url' => '/v1.yaml'],
+        ['title' => 'v2', 'url' => '/v2.yaml', 'default' => true],
+    ]);
+
+    expect(Scalar::configuration()['sources'])->toBe([
+        ['title' => 'v1', 'url' => '/v1.yaml'],
+        ['title' => 'v2', 'url' => '/v2.yaml', 'default' => true],
+    ]);
+});
+
+it('falls back to the single document when the sources config is empty', function () {
+    config()->set('scalar.sources', []);
+    config()->set('scalar.url', '/openapi.yaml');
+
+    $configuration = Scalar::configuration();
+
+    expect($configuration['url'])->toBe('/openapi.yaml')
+        ->and($configuration->has('sources'))->toBeFalse();
+});
+
+it('ignores a non-array sources config', function () {
+    config()->set('scalar.sources', 'nonsense');
+    config()->set('scalar.url', '/openapi.yaml');
+
+    expect(Scalar::configuration()->has('sources'))->toBeFalse();
+});
+
+it('prefers registered documents over the sources config', function () {
+    config()->set('scalar.sources', [['url' => '/from-config.yaml']]);
+    Scalar::document('Registered')->url('/registered.yaml');
+
+    expect(Scalar::configuration()['sources'])->toBe([
+        ['title' => 'Registered', 'url' => '/registered.yaml'],
+    ]);
+});
+
+it('renders sources through the reference view', function () {
+    Scalar::document('API')->url('/openapi.yaml');
+
+    $this->get(config('scalar.path'))
+        ->assertOk()
+        ->assertSee('"sources":', false);
+});
+
+/*
+|--------------------------------------------------------------------------
+| Document value object
+|--------------------------------------------------------------------------
+*/
+
+it('builds a source from a document url', function () {
+    expect((new Document)->url('/openapi.yaml')->toArray())
+        ->toBe(['url' => '/openapi.yaml']);
+});
+
+it('builds a source from document content', function () {
+    expect((new Document)->content('{"openapi":"3.1.0"}')->toArray())
+        ->toBe(['content' => '{"openapi":"3.1.0"}']);
+});
+
+it('prefers document content over its url', function () {
+    expect((new Document)->url('/openapi.yaml')->content('{"openapi":"3.1.0"}')->toArray())
+        ->toBe(['content' => '{"openapi":"3.1.0"}']);
+});
+
+it('reads a document file into content', function () {
+    $source = (new Document)->file(__DIR__.'/Fixtures/openapi.json')->toArray();
+
+    expect($source['content'])->toContain('Fixture API')
+        ->and($source)->not->toHaveKey('url');
+});
+
+it('includes title, slug and default in the source', function () {
+    expect((new Document)->title('T')->slug('s')->url('/o.yaml')->default()->toArray())
+        ->toBe(['title' => 'T', 'slug' => 's', 'url' => '/o.yaml', 'default' => true]);
+});
+
+it('throws when a document file does not exist', function () {
+    (new Document)->file(__DIR__.'/Fixtures/does-not-exist.json')->toArray();
+})->throws(MissingOpenApiDocument::class);
+
+it('throws when a document has no source', function () {
+    (new Document)->toArray();
+})->throws(MissingOpenApiDocument::class);
+
+it('throws when a document url is empty', function () {
+    (new Document)->url('')->toArray();
+})->throws(MissingOpenApiDocument::class);
+
+it('throws when document content is empty', function () {
+    (new Document)->content('')->toArray();
+})->throws(MissingOpenApiDocument::class);
+
+it('ignores an empty document file path', function () {
+    expect((new Document)->file('')->content('{"openapi":"3.1.0"}')->toArray())
+        ->toBe(['content' => '{"openapi":"3.1.0"}']);
+});
+
+it('builds a document from an array', function () {
+    expect(Document::fromArray([
+        'title' => 'T',
+        'slug' => 's',
+        'url' => '/o.yaml',
+        'default' => true,
+    ])->toArray())->toBe(['title' => 'T', 'slug' => 's', 'url' => '/o.yaml', 'default' => true]);
+});
+
+it('builds a document from an array with content', function () {
+    expect(Document::fromArray(['content' => '{"openapi":"3.1.0"}'])->toArray())
+        ->toBe(['content' => '{"openapi":"3.1.0"}']);
+});
+
+it('builds a document from an array with a file', function () {
+    expect(Document::fromArray(['file' => __DIR__.'/Fixtures/openapi.json'])->toArray()['content'])
+        ->toContain('Fixture API');
+});
+
+it('builds a document from an array without optional keys', function () {
+    expect(Document::fromArray(['url' => '/o.yaml'])->toArray())
+        ->toBe(['url' => '/o.yaml']);
+});
+
+it('does not mark a document as default when the flag is false', function () {
+    expect(Document::fromArray(['url' => '/o.yaml', 'default' => false])->toArray())
+        ->not->toHaveKey('default');
 });

--- a/tests/ScalarTest.php
+++ b/tests/ScalarTest.php
@@ -292,6 +292,11 @@ it('renders sources through the reference view', function () {
         ->assertSee('"sources":', false);
 });
 
+it('registers the document manager as a singleton', function () {
+    // A shared instance is what lets registered documents survive to render time.
+    expect(app(\Scalar\Scalar::class))->toBe(app(\Scalar\Scalar::class));
+});
+
 /*
 |--------------------------------------------------------------------------
 | Document value object


### PR DESCRIPTION
Adds first-class support for rendering **multiple OpenAPI documents** behind Scalar's document switcher — versioned APIs (`v1`/`v2`), public vs. internal, etc.

Two ways to define them:

**Config `sources`:**
```php
'sources' => [
    ['title' => 'API v1', 'slug' => 'v1', 'url' => '/openapi/v1.yaml'],
    ['title' => 'API v2', 'slug' => 'v2', 'url' => '/openapi/v2.yaml', 'default' => true],
],
```

**Programmatic registrar** (e.g. in a service provider, for dynamic lists):
```php
use Scalar\Facades\Scalar;

Scalar::document('API v1')->url('/openapi/v1.yaml');
Scalar::document('API v2')->file(storage_path('app/openapi/v2.json'))->default();
```

### How it works
- `Scalar` is now a singleton **manager** with a document registrar; the facade resolves it.
- A `Document` value object carries `title`/`slug`/`url`/`content`/`file`/`default` and builds a Scalar `source`.
- Precedence: registered documents → `sources` config → single `url`/`content`/`file`.
- A single document still renders flat (unchanged), so this is **backward compatible**.

No Blade component in this PR (deferred by request).