### PR TITLE
chore: drop Laravel 10 support and require Pest 3

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -18,17 +18,12 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         php: [8.5, 8.4, 8.3, 8.2]
-        laravel: [13.*, 12.*, 11.*, 10.*]
+        laravel: [13.*, 12.*, 11.*]
         stability: [prefer-lowest, prefer-stable]
         exclude:
           # Laravel 13 dropped PHP 8.2
           - php: 8.2
             laravel: 13.*
-          # Laravel 10 only supports up to PHP 8.3
-          - php: 8.4
-            laravel: 10.*
-          - php: 8.5
-            laravel: 10.*
           # Laravel 11 only supports up to PHP 8.4
           - php: 8.5
             laravel: 11.*
@@ -41,9 +36,6 @@ jobs:
             carbon: ^3.0
           - laravel: 11.*
             testbench: 9.*
-            carbon: ^2.63
-          - laravel: 10.*
-            testbench: 8.*
             carbon: ^2.63
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ This file provides guidance to Coding Agents when working with code in this repo
 
 `scalar/laravel` is a **Laravel package** (not an application) that renders modern API references from an OpenAPI document. It exposes a single route (`/scalar` by default) that serves an HTML page loading the Scalar API reference from a CDN, configured entirely through `config/scalar.php`.
 
-The package is built on [spatie/laravel-package-tools](https://github.com/spatie/laravel-package-tools) and is tested against Laravel 10–13 / PHP 8.2–8.3 using [Orchestra Testbench](https://github.com/orchestral/testbench).
+The package is built on [spatie/laravel-package-tools](https://github.com/spatie/laravel-package-tools) and is tested against Laravel 11–13 / PHP 8.2–8.5 using [Orchestra Testbench](https://github.com/orchestral/testbench).
 
 ## Commands
 

--- a/composer.json
+++ b/composer.json
@@ -17,19 +17,19 @@
         }
     ],
     "require": {
-        "php": "^8.2||^8.3",
+        "php": "^8.2",
         "spatie/laravel-package-tools": "^1.16",
-        "illuminate/contracts": "^10.0||^11.0||^12.0||^13.0"
+        "illuminate/contracts": "^11.0||^12.0||^13.0"
     },
     "require-dev": {
-        "larastan/larastan": "^2.9||^3.0",
+        "larastan/larastan": "^3.0",
         "laravel/pint": "^1.14",
-        "nunomaduro/collision": "^8.7.0||^7.10.0",
-        "orchestra/testbench": "^8.0||^9.0||^10.0||^11.0",
-        "pestphp/pest": "^2.3.4||^3.7.4||^4.0||^5.0",
-        "pestphp/pest-plugin-arch": "^2.7.0||^3.0.0||^4.0||^5.0",
-        "pestphp/pest-plugin-laravel": "^2.3.0||^3.1.0||^4.0||^5.0",
-        "pestphp/pest-plugin-type-coverage": "^2.0||^3.0||^4.0||^5.0"
+        "nunomaduro/collision": "^8.7.0",
+        "orchestra/testbench": "^9.0||^10.0||^11.0",
+        "pestphp/pest": "^3.7.4||^4.0||^5.0",
+        "pestphp/pest-plugin-arch": "^3.0.0||^4.0||^5.0",
+        "pestphp/pest-plugin-laravel": "^3.1.0||^4.0||^5.0",
+        "pestphp/pest-plugin-type-coverage": "^3.0||^4.0||^5.0"
     },
     "autoload": {
         "psr-4": {

--- a/tests/ArchTest.php
+++ b/tests/ArchTest.php
@@ -3,7 +3,11 @@
 use Illuminate\Support\Facades\Facade;
 
 arch('it will not use debugging functions')
-    ->expect(['dd', 'ddd', 'dump', 'ray'])
+    ->expect(['dd', 'ddd', 'dump', 'ray', 'var_dump', 'die', 'phpinfo'])
+    ->each->not->toBeUsed();
+
+arch('it will not use insecure functions')
+    ->expect(['eval', 'exec', 'shell_exec', 'system', 'passthru', 'md5', 'sha1', 'unserialize', 'extract'])
     ->each->not->toBeUsed();
 
 arch('it uses strict types')
@@ -26,7 +30,3 @@ arch('exceptions extend RuntimeException')
 arch('the document value object is final')
     ->expect('Scalar\Document')
     ->toBeFinal();
-
-arch()->preset()->php();
-
-arch()->preset()->security();

--- a/tests/ArchTest.php
+++ b/tests/ArchTest.php
@@ -1,5 +1,32 @@
 <?php
 
+use Illuminate\Support\Facades\Facade;
+
 arch('it will not use debugging functions')
-    ->expect(['dd', 'dump', 'ray'])
+    ->expect(['dd', 'ddd', 'dump', 'ray'])
     ->each->not->toBeUsed();
+
+arch('it uses strict types')
+    ->expect('Scalar')
+    ->toUseStrictTypes();
+
+arch('controllers are invokable and suffixed')
+    ->expect('Scalar\Controllers')
+    ->toBeInvokable()
+    ->toHaveSuffix('Controller');
+
+arch('the facade extends the Laravel facade')
+    ->expect('Scalar\Facades\Scalar')
+    ->toExtend(Facade::class);
+
+arch('exceptions extend RuntimeException')
+    ->expect('Scalar\Exceptions')
+    ->toExtend(RuntimeException::class);
+
+arch('the document value object is final')
+    ->expect('Scalar\Document')
+    ->toBeFinal();
+
+arch()->preset()->php();
+
+arch()->preset()->security();

--- a/tests/ArchTest.php
+++ b/tests/ArchTest.php
@@ -2,12 +2,12 @@
 
 use Illuminate\Support\Facades\Facade;
 
-arch('it will not use debugging functions')
-    ->expect(['dd', 'ddd', 'dump', 'ray', 'var_dump', 'die', 'phpinfo'])
-    ->each->not->toBeUsed();
+arch()->preset()->php();
 
-arch('it will not use insecure functions')
-    ->expect(['eval', 'exec', 'shell_exec', 'system', 'passthru', 'md5', 'sha1', 'unserialize', 'extract'])
+arch()->preset()->security();
+
+arch('it will not use Laravel debug helpers')
+    ->expect(['dd', 'ddd'])
     ->each->not->toBeUsed();
 
 arch('it uses strict types')


### PR DESCRIPTION
Drops Laravel 10 support so the toolchain can move to **Pest 3+**, which unlocks the arch **presets**.

### Support matrix
- **Removed:** Laravel 10 (testbench 8, Pest 2) from the CI matrix and constraints
- Now: **Laravel 11–13**, **PHP 8.2–8.5**, Pest 3/4/5
- Raised floors: `illuminate ^11`, `pestphp/pest ^3.7.4`, `larastan ^3.0`, `collision ^8`; collapsed the redundant `^8.2||^8.3` php constraint to `^8.2`

### Arch tests
- Switched to Pest's `php` and `security` **presets** (the reason for the Pest 3 bump) plus a small `dd`/`ddd` check
- Kept the structural rules: strict types, invokable+suffixed controllers, facade extends `Facade`, exceptions extend `RuntimeException`, `Document` is `final`

**Breaking** for anyone on Laravel 10 — warrants the `0.4.0` release note.