### PR TITLE
refactor: dedupe document resolution, add flush(), tidy .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,20 +1,15 @@
 # Path-based git attributes
 # https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
 
-# Ignore all test and documentation with "export-ignore".
+# Exclude development and meta files from the distributed package.
 /.github            export-ignore
 /.gitattributes     export-ignore
 /.gitignore         export-ignore
+/.editorconfig      export-ignore
 /phpunit.xml.dist   export-ignore
-/art                export-ignore
-/docs               export-ignore
+/phpstan.neon       export-ignore
+/testbench.yaml     export-ignore
 /tests              export-ignore
 /workbench          export-ignore
-/.editorconfig      export-ignore
-/.php_cs.dist.php   export-ignore
-/psalm.xml          export-ignore
-/psalm.xml.dist     export-ignore
-/testbench.yaml     export-ignore
-/UPGRADING.md       export-ignore
-/phpstan.neon.dist  export-ignore
-/phpstan-baseline.neon  export-ignore
+/AGENTS.md          export-ignore
+/CLAUDE.md          export-ignore

--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ Scalar::document('API v2')->file(storage_path('app/openapi/v2.json'))->default()
 
 Registered documents take precedence over the `sources` config.
 
+> Under [Laravel Octane](https://laravel.com/docs/octane) the manager is a long-lived singleton, so register documents once (in a service provider). If you register per request, call `Scalar::flush()` first to avoid them stacking up.
+
 ## Authorization
 
 The Scalar API reference may be accessed via the /scalar route. By default, everyone will be able to access this route. However, within your App\Providers\AppServiceProvider.php file, you can overwrite the gate definition. This authorization gate controls access to Scalar in non-local environments. You are free to modify this gate as needed to restrict access to your documentation:

--- a/src/Document.php
+++ b/src/Document.php
@@ -136,16 +136,24 @@ final class Document
         return $source;
     }
 
+    /**
+     * Read an OpenAPI document from a local file, embedding its contents.
+     */
+    public static function readFile(string $file): string
+    {
+        if (! is_file($file)) {
+            throw new MissingOpenApiDocument(
+                "The configured OpenAPI document could not be found at: {$file}"
+            );
+        }
+
+        return File::get($file);
+    }
+
     protected function resolveContent(): ?string
     {
         if ($this->file !== null && $this->file !== '') {
-            if (! is_file($this->file)) {
-                throw new MissingOpenApiDocument(
-                    "The configured OpenAPI document could not be found at: {$this->file}"
-                );
-            }
-
-            return File::get($this->file);
+            return self::readFile($this->file);
         }
 
         return $this->content !== null && $this->content !== '' ? $this->content : null;

--- a/src/Facades/Scalar.php
+++ b/src/Facades/Scalar.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\Facade;
 
 /**
  * @method static \Scalar\Document document(?string $title = null)
+ * @method static void flush()
  * @method static array<array-key, \Scalar\Document> documents()
  * @method static string pageTitle()
  * @method static string|null url()

--- a/src/Scalar.php
+++ b/src/Scalar.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Scalar;
 
 use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\File;
 use Scalar\Exceptions\MissingOpenApiDocument;
 
 class Scalar
@@ -28,6 +27,18 @@ class Scalar
         $this->documents[] = $document;
 
         return $document;
+    }
+
+    /**
+     * Forget all programmatically registered documents.
+     *
+     * The manager is a long-lived singleton, so under Laravel Octane you should
+     * register documents once (in a service provider) or flush them yourself if
+     * you register per request.
+     */
+    public function flush(): void
+    {
+        $this->documents = [];
     }
 
     /**
@@ -80,13 +91,7 @@ class Scalar
         $file = config('scalar.file');
 
         if (is_string($file) && $file !== '') {
-            if (! is_file($file)) {
-                throw new MissingOpenApiDocument(
-                    "The configured OpenAPI document could not be found at: {$file}"
-                );
-            }
-
-            return File::get($file);
+            return Document::readFile($file);
         }
 
         /** Otherwise, use the inline content as-is. */

--- a/tests/ScalarTest.php
+++ b/tests/ScalarTest.php
@@ -297,6 +297,15 @@ it('registers the document manager as a singleton', function () {
     expect(app(\Scalar\Scalar::class))->toBe(app(\Scalar\Scalar::class));
 });
 
+it('flushes registered documents', function () {
+    Scalar::document('API')->url('/openapi.yaml');
+    expect(Scalar::documents())->toHaveCount(1);
+
+    Scalar::flush();
+
+    expect(Scalar::documents())->toBe([]);
+});
+
 /*
 |--------------------------------------------------------------------------
 | Document value object


### PR DESCRIPTION
Cheap cleanup from the audit — no behavior change to existing usage.

**Dedupe document resolution.** The file read/throw block was duplicated in `Scalar::content()` and `Document::resolveContent()`. Extracted it into a single `Document::readFile()` that both call. `Scalar::url()`/`content()` stay public (they were reachable in 0.3.0).

**Octane-friendly reset.** Added `Scalar::flush()` to clear registered documents, plus a README note: the manager is a long-lived singleton, so register documents once in a service provider (they persist per worker) or `flush()` first if you register per request. No auto-flush — that would wipe boot-time registrations.

**`.gitattributes` hygiene.** It was stale spatie-skeleton boilerplate: `export-ignore`d files that don't exist here and missed the committed `phpstan.neon`, `AGENTS.md`, `CLAUDE.md` (which were shipping in the Packagist dist). Fixed.

Left `_integration` as bare `'laravel'` per your call — not adding the version.